### PR TITLE
Filter out lines and methods without a 'line' attribute

### DIFF
--- a/cover2cover.py
+++ b/cover2cover.py
@@ -11,11 +11,20 @@ def find_lines(j_package, filename):
     """Return all <line> elements for a given source file in a package."""
     xpath = "sourcefile[@name='" + os.path.basename(filename) + "']/line"
     return list(j_package.findall(xpath))
+    
+def line_is_after(jm, start_line):
+    if ('line' in jm):
+        int(jm.attrib['line']) > start_line
+    else:
+        False
 
 def method_lines(jmethod, jmethods, jlines):
     """Filter the lines from the given set of jlines that apply to the given jmethod."""
-    start_line = int(jmethod.attrib['line'])
-    larger     = list(int(jm.attrib['line']) for jm in jmethods if int(jm.attrib['line']) > start_line)
+    if ('line' in jmethod):
+        start_line = int(jmethod.attrib['line'])
+    else:
+        start_line = 0
+    larger     = list(int(jm.attrib['line']) for jm in jmethods if line_is_after(jm, start_line))
     end_line   = min(larger) if len(larger) else 99999999
 
     for jline in jlines:

--- a/cover2cover.py
+++ b/cover2cover.py
@@ -8,9 +8,13 @@ import os.path
 # branch="true" hits="1" number="86"
 
 def find_lines(j_package, filename):
-    """Return all <line> elements for a given source file in a package."""
-    xpath = "sourcefile[@name='" + os.path.basename(filename) + "']/line"
-    return list(j_package.findall(xpath))
+   """Return all <line> elements for a given source file in a package."""
+   lines = list()
+   sourcefiles = j_package.findall("sourcefile")
+   for sourcefile in sourcefiles:
+       if sourcefile.attrib.get("name") == os.path.basename(filename):
+           lines = lines + sourcefile.findall("line")
+   return lines
 
 def line_is_after(jm, start_line):
     if ('line' in jm):
@@ -71,14 +75,21 @@ def sum(covered, missed):
     return covered + missed
 
 def counter(source, type, operation=fraction):
-    c = source.find('counter[@type="' + type + '"]')
-    if c is not None:
-        covered = float(c.attrib['covered'])
-        missed  = float(c.attrib['missed'])
+   c = source.find('counter')
+   out_c = None
+   for cs in c:
+       if cs.attrib.get('type') == type:
+           out_c = cs
+           break
+   c = out_c
 
-        return str(operation(covered, missed))
-    else:
-        return '0.0'
+   if c is not None:
+       covered = float(c.attrib['covered'])
+       missed  = float(c.attrib['missed'])
+
+       return str(operation(covered, missed))
+   else:
+       return '0.0'
 
 def convert_method(j_method, j_lines):
     c_method = ET.Element('method')

--- a/cover2cover.py
+++ b/cover2cover.py
@@ -11,7 +11,7 @@ def find_lines(j_package, filename):
     """Return all <line> elements for a given source file in a package."""
     xpath = "sourcefile[@name='" + os.path.basename(filename) + "']/line"
     return list(j_package.findall(xpath))
-    
+
 def line_is_after(jm, start_line):
     if ('line' in jm):
         int(jm.attrib['line']) > start_line


### PR DESCRIPTION
Sometimes we have encountered jm and jmethod objects that don't have a 'line' attribute, which caused the conversion to crash.
I am not sure if the changes that I have made will compromise the quality of the conversion, or if my code is taking the right approach.
