### PR TITLE
Add group level present in aggregate Jacoco report

### DIFF
--- a/cover2cover.py
+++ b/cover2cover.py
@@ -128,6 +128,11 @@ def convert_root(source, target, source_roots):
         ET.SubElement(sources, 'source').text = s
 
     packages = ET.SubElement(target, 'packages')
+    
+    for group in source.findall('group'):
+        for package in group.findall('package'):
+            packages.append(convert_package(package))
+
     for package in source.findall('package'):
         packages.append(convert_package(package))
 


### PR DESCRIPTION
Hi,
Thanks for the script,
I just had to add group level present in aggregate reports
https://www.eclemma.org/jacoco/trunk/doc/report-aggregate-mojo.html
as defined in DTD
http://www.eclemma.org/jacoco/trunk/coverage/report.dtd

Note : my fork includes captainmalloc work on python3 compatibilty