### PR TITLE
Fix issue #12

### DIFF
--- a/cover2cover.py
+++ b/cover2cover.py
@@ -143,7 +143,7 @@ def jacoco2cobertura(filename, source_roots):
     into = ET.Element('coverage')
     convert_root(root, into, source_roots)
     print('<?xml version="1.0" ?>')
-    print(ET.tostring(into))
+    print(ET.tostring(into, encoding='unicode'))
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:

--- a/cover2cover.py
+++ b/cover2cover.py
@@ -143,7 +143,10 @@ def jacoco2cobertura(filename, source_roots):
     into = ET.Element('coverage')
     convert_root(root, into, source_roots)
     print('<?xml version="1.0" ?>')
-    print(ET.tostring(into, encoding='unicode'))
+    if sys.version_info[0] < 3:
+        print(ET.tostring(into))
+    else:
+        print(ET.tostring(into, encoding='unicode'))
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:


### PR DESCRIPTION
`b'<coverage ... </coverage>'` suggests that the XML content is being treated as a byte string rather than a regular string. This often happens in Python 3 when dealing with outputs from certain operations, like those involving file reading or external data manipulation, which return data in bytes format.

The ET.tostring() function from the xml.etree.ElementTree module, by default, returns the XML content as a byte string in Python 3.
By specifying encoding='unicode', ET.tostring() will return a regular string instead of a byte string.